### PR TITLE
Rename abbreviations into full names

### DIFF
--- a/src/main/java/com/coderfromscratch/httpserver/util/Json.java
+++ b/src/main/java/com/coderfromscratch/httpserver/util/Json.java
@@ -10,21 +10,21 @@ public class Json {
     private static ObjectMapper myObjectMapper = defaultObjectMapper();
 
     private static ObjectMapper defaultObjectMapper() {
-        ObjectMapper om = new ObjectMapper();
-        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return om;
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
     }
 
-    public static JsonNode parse(String jsonSrc) throws IOException {
-        return myObjectMapper.readTree(jsonSrc);
+    public static JsonNode parse(String jsonSource) throws IOException {
+        return myObjectMapper.readTree(jsonSource);
     }
 
     public static <A> A fromJson(JsonNode node , Class<A> clazz) throws JsonProcessingException {
         return myObjectMapper.treeToValue(node, clazz);
     }
 
-    public static JsonNode toJson(Object obj) {
-        return myObjectMapper.valueToTree(obj);
+    public static JsonNode toJson(Object object) {
+        return myObjectMapper.valueToTree(object);
     }
 
     public static String stringify(JsonNode node) throws JsonProcessingException {
@@ -35,11 +35,11 @@ public class Json {
         return generateJson(node, true);
     }
 
-    private static String generateJson(Object o, boolean pretty) throws JsonProcessingException {
+    private static String generateJson(Object object, boolean pretty) throws JsonProcessingException {
         ObjectWriter objectWriter = myObjectMapper.writer();
         if (pretty) {
             objectWriter = objectWriter.with(SerializationFeature.INDENT_OUTPUT);
         }
-        return objectWriter.writeValueAsString(o);
+        return objectWriter.writeValueAsString(object);
     }
 }


### PR DESCRIPTION
Abbreviations are not required here for readability,
so they are renamed to their original full meaning.