### PR TITLE
Make ConfigurationManager thread safe

### DIFF
--- a/src/main/java/com/coderfromscratch/httpserver/config/ConfigurationManager.java
+++ b/src/main/java/com/coderfromscratch/httpserver/config/ConfigurationManager.java
@@ -16,7 +16,7 @@ public class ConfigurationManager {
     private ConfigurationManager() {
     }
 
-    public static ConfigurationManager getInstance() {
+    public static synchronized ConfigurationManager getInstance() {
         if (myConfigurationManager==null)
             myConfigurationManager = new ConfigurationManager();
         return myConfigurationManager;


### PR DESCRIPTION
Because the if statement and the constructor are together a valid action,
they need to be executed without a different thread intertwining.
To ensure this, the `synchronized` keyword is added to the method signature.